### PR TITLE
feat: adding new metric types

### DIFF
--- a/varnishprom.go
+++ b/varnishprom.go
@@ -499,6 +499,13 @@ func main() {
 							metric.LabelNames = []string{"backend", "director", "host", "type"}
 							metric.LabelValues = []string{backend, director, *hostname, backendtype}
 							setGauge(metric)
+						} else if metric.Type == "q" || metric.Type == "b" {
+							metric.Name = "varnishstat_backend_" + counter
+							metric.LabelNames = []string{"backend", "director", "host", "type"}
+							metric.LabelValues = []string{backend, director, *hostname, backendtype}
+							setGauge(metric)
+						} else {
+							log.Debug("Unknown metric type", "metrictype", metric.Type)
 						}
 					} else if strings.HasPrefix(key, "VBE.") {
 						// Not the current VCL. Skip these.


### PR DESCRIPTION
There are more metric types than what the exporter currently supports. This introduces the `b` (boolean) type and the `q` semantic type. 

Changes:
* Expose varnishstat output with type `b` and `q`
